### PR TITLE
Uribeacon update

### DIFF
--- a/services/URIBeaconConfigService.h
+++ b/services/URIBeaconConfigService.h
@@ -17,10 +17,6 @@
 #ifndef SERVICES_URIBEACONCONFIGSERVICE_H_
 #define SERVICES_URIBEACONCONFIGSERVICE_H_
 
-#include "BLEDevice.h"
-#include "GattCharacteristic.h"
-#include "mbed.h"
-
 #define UUID_URI_BEACON(FIRST, SECOND) { \
         0xee, 0x0c, FIRST, SECOND, 0x87, 0x86, 0x40, 0xba,       \
         0xab, 0x96, 0x99, 0xb9, 0x1a, 0xc9, 0x81, 0xd8,          \
@@ -157,6 +153,7 @@ class URIBeaconConfigService {
 
 
   private:
+    // True if the lock bits are non-zero
     bool isLocked() {
         Lock_t testLock;
         memset(testLock, 0, sizeof(Lock_t));
@@ -174,7 +171,8 @@ class URIBeaconConfigService {
         if (handle == lockChar.getValueHandle()) {
             // Validated earlier
             memcpy(params.lock, writeParams->data, sizeof(Lock_t));
-            lockedState = true;
+            // use isLocked() in case bits are being set to all 0's
+            lockedState = isLocked();
         } else if (handle == unlockChar.getValueHandle()) {
             // Validated earlier
             memset(params.lock, 0, sizeof(Lock_t));

--- a/services/URIBeaconConfigService.h
+++ b/services/URIBeaconConfigService.h
@@ -53,7 +53,7 @@ class URIBeaconConfigService {
     static const uint8_t TX_POWER_MODE_LOW    = 1; /*!< Low TX power mode */
     static const uint8_t TX_POWER_MODE_MEDIUM = 2; /*!< Medium TX power mode */
     static const uint8_t TX_POWER_MODE_HIGH   = 3; /*!< High TX power mode */
-    static const unisgned int NUM_POWER_MODES = 4; /*!< Number of Power Modes defined */
+    static const unsigned int NUM_POWER_MODES = 4; /*!< Number of Power Modes defined */
 
 
     typedef uint8_t Lock_t[16];               /* 128 bits */

--- a/services/URIBeaconConfigService.h
+++ b/services/URIBeaconConfigService.h
@@ -53,7 +53,7 @@ class URIBeaconConfigService {
     static const uint8_t TX_POWER_MODE_LOW    = 1; /*!< Low TX power mode */
     static const uint8_t TX_POWER_MODE_MEDIUM = 2; /*!< Medium TX power mode */
     static const uint8_t TX_POWER_MODE_HIGH   = 3; /*!< High TX power mode */
-    static const int NUM_POWER_MODES = 4;      /*!< Number of Power Modes defined */
+    static const unisgned int NUM_POWER_MODES = 4; /*!< Number of Power Modes defined */
 
 
     typedef uint8_t Lock_t[16];               /* 128 bits */


### PR DESCRIPTION
remove methods that update while running config service, this is an unlikely use case
fix characteristics table to include all
rename const UUIDs to fit naming style
don't assume URI is a URL and remove encoding methods
add defaults, which are used for reset, as distrinct from params
Use new style of readonly writeonly characteristic declarations
let caller manage the advertising for both Config mode and Beacon
astyle formatting