### PR TITLE
added API for creating iBeacons

### DIFF
--- a/services/iBeaconService.h
+++ b/services/iBeaconService.h
@@ -1,0 +1,73 @@
+/* mbed Microcontroller Library
+ * Copyright (c) 2006-2015 ARM Limited
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#ifndef __BLE_IBEACON_SERVICE_H__
+#define __BLE_IBEACON_SERVICE_H__
+
+#include "BLEDevice.h"
+
+/**
+* @class iBeaconService
+* @brief iBeacon Service. This service sets up a device to broadcast advertising packets to mimic an iBeacon<br>
+*/
+
+class iBeaconService
+{
+public:
+    iBeaconService(BLEDevice &_ble, uint8_t proxUUID[16],uint16_t majNum,uint16_t minNum,uint8_t txP=0xC8, uint16_t compID=0x004C):
+        ble(_ble)
+    {
+        data.ID =  0x02;         // Optional ID field
+        data.len = 0x15;         // Len of remaining stuff (16B UUID, 2B Maj, 2B Min, 1B TxP)
+        data.majorNumber = ((majNum<<8) | (majNum >>8));
+        data.minorNumber = ((minNum<<8) | (minNum >>8));
+        data.txPower = txP;      // The user should calibrate this to ~1meter fromt he device
+        data.companyID = compID; // Note: all iBeacons use the Apple ID of 0x004C
+
+        // copy across proximity UUID
+        for(int x=0; x<sizeof(data.proximityUUID); x++) {
+            data.proximityUUID[x]=proxUUID[x];
+        }
+
+        // Set up iBeacon data
+        // Generate the 0x020106 part of the iBeacon Prefix
+        ble.accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED | GapAdvertisingData::LE_GENERAL_DISCOVERABLE );
+        // Generate the 0x1AFF part of the iBeacon Prefix
+        ble.accumulateAdvertisingPayload(GapAdvertisingData::MANUFACTURER_SPECIFIC_DATA, data.raw, sizeof(data.raw));
+
+        // Set advertising type
+        ble.setAdvertisingType(GapAdvertisingParams::ADV_NON_CONNECTABLE_UNDIRECTED);
+    }
+
+public:
+    union {
+        uint8_t raw[25];
+        struct {
+            uint16_t companyID;
+            uint8_t ID;
+            uint8_t len;
+            uint8_t proximityUUID[16];
+            uint16_t majorNumber;
+            uint16_t minorNumber;
+            uint8_t txPower;
+        };
+    } data;
+
+private:
+    BLEDevice &ble;
+
+};
+
+#endif //__BLE_IBEACON_SERVICE_H__


### PR DESCRIPTION
# Problem
making iBeacons is really really really hard

The iBeacon example program on the website has code that looks like this:
```C++
   /**
     * The Beacon payload (encapsulated within the MSD advertising data structure)
     * has the following composition:
     * 128-Bit UUID = E2 0A 39 F4 73 F5 4B C4 A1 2F 17 D1 AD 07 A9 61
     * Major/Minor  = 0000 / 0000
     * Tx Power     = C8 (-56dB)
     */
    const static uint8_t iBeaconPayload[] = {
        0x4C, 0x00, // Company identifier code (0x004C == Apple)
        0x02,       // ID
        0x15,       // length of the remaining payload
        0xE2, 0x0A, 0x39, 0xF4, 0x73, 0xF5, 0x4B, 0xC4, // location UUID
        0xA1, 0x2F, 0x17, 0xD1, 0xAD, 0x07, 0xA9, 0x61,
        0x00, 0x00, // the major value to differentiate a location
        0x00, 0x00, // the minor value to differentiate a location
        0xC8        // 2's complement of the Tx power (-56dB)
    };
 
int main(void)
{
    /* Initialize BLE baselayer */
    ble.init();
    
    /* Set up iBeacon data*/
    ble.accumulateAdvertisingPayload(GapAdvertisingData::BREDR_NOT_SUPPORTED | GapAdvertisingData::LE_GENERAL_DISCOVERABLE );
    ble.accumulateAdvertisingPayload(GapAdvertisingData::MANUFACTURER_SPECIFIC_DATA, iBeaconPayload, sizeof(iBeaconPayload));
 
    /* Set advertising interval. Longer interval = longer battery life */
    ble.setAdvertisingType(GapAdvertisingParams::ADV_NON_CONNECTABLE_UNDIRECTED);
    ble.setAdvertisingInterval(160); /* 100ms; in multiples of 0.625ms. */
    ble.startAdvertising();
```

# Solution
add this "service" to hide the bullshit and make it easier to use. Now the same code looks like this:
```C++

uint8_t uuid[] = {0xE2, 0x0A, 0x39, 0xF4, 0x73, 0xF5, 0x4B, 0xC4,
                  0xA1, 0x2F, 0x17, 0xD1, 0xAD, 0x07, 0xA9, 0x61
                 };
uint16_t majorNumber = 0x1122;
uint16_t minorNumber = 0x3344;
uint16_t txPower = 0xC8;

int main(void)
{
    // Initialize BLE baselayer
    ble.init();

    // Initialize ibeacon
    iBeaconService ibeacon(ble, uuid, majorNumber, minorNumber, txPower);

    // Set advertising time
    ble.setAdvertisingInterval(160); /* 100ms; in multiples of 0.625ms. */
    ble.startAdvertising();

```

The API exposes the 4 key characteristics required for an iBeacon, the UUID, Major Number, Minor Number, and TxPower level. 

@rgrover @jaustin @sg- 

I have an update pending and ready for the example code, will push it once this is added to the BLE library and pulled into the website code base.