### PR TITLE
Added callback on characteristic reads

### DIFF
--- a/public/BLEDevice.h
+++ b/public/BLEDevice.h
@@ -263,8 +263,8 @@ public:
      * @Note: it is also possible to setup a callback into a member function of
      * some object.
      */
-    void onDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP));
-    template <typename T> void onDataRead(T * objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context));
+    ble_error_t onDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP));
+    template <typename T> ble_error_t onDataRead(T * objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context));
 
     void onUpdatesEnabled(GattServer::EventCallback_t callback);
     void onUpdatesDisabled(GattServer::EventCallback_t callback);
@@ -567,14 +567,14 @@ BLEDevice::onDataWritten(T *objPtr, void (T::*memberPtr)(const GattCharacteristi
     transport->getGattServer().setOnDataWritten(objPtr, memberPtr);
 }
 
-inline void
+inline ble_error_t
 BLEDevice::onDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP)) {
-    transport->getGattServer().setOnDataRead(callback);
+    return transport->getGattServer().setOnDataRead(callback);
 }
 
-template <typename T> inline void
+template <typename T> inline ble_error_t
 BLEDevice::onDataRead(T *objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context)) {
-    transport->getGattServer().setOnDataRead(objPtr, memberPtr);
+    return transport->getGattServer().setOnDataRead(objPtr, memberPtr);
 }
 
 inline void

--- a/public/BLEDevice.h
+++ b/public/BLEDevice.h
@@ -252,6 +252,20 @@ public:
     void onDataWritten(void (*callback)(const GattCharacteristicWriteCBParams *eventDataP));
     template <typename T> void onDataWritten(T * objPtr, void (T::*memberPtr)(const GattCharacteristicWriteCBParams *context));
 
+    /**
+     * Setup a callback for when a characteristic is being read by a client.
+     *
+     * @Note: it is possible to chain together multiple onDataRead callbacks
+     * (potentially from different modules of an application) to receive updates
+     * to characteristics. Services may add their own onDataRead callbacks
+     * behind the scenes to trap interesting events.
+     *
+     * @Note: it is also possible to setup a callback into a member function of
+     * some object.
+     */
+    void onDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP));
+    template <typename T> void onDataRead(T * objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context));
+
     void onUpdatesEnabled(GattServer::EventCallback_t callback);
     void onUpdatesDisabled(GattServer::EventCallback_t callback);
     void onConfirmationReceived(GattServer::EventCallback_t callback);
@@ -551,6 +565,16 @@ BLEDevice::onDataWritten(void (*callback)(const GattCharacteristicWriteCBParams 
 template <typename T> inline void
 BLEDevice::onDataWritten(T *objPtr, void (T::*memberPtr)(const GattCharacteristicWriteCBParams *context)) {
     transport->getGattServer().setOnDataWritten(objPtr, memberPtr);
+}
+
+inline void
+BLEDevice::onDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP)) {
+    transport->getGattServer().setOnDataRead(callback);
+}
+
+template <typename T> inline void
+BLEDevice::onDataRead(T *objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context)) {
+    transport->getGattServer().setOnDataRead(objPtr, memberPtr);
 }
 
 inline void

--- a/public/GattCharacteristicCallbackParams.h
+++ b/public/GattCharacteristicCallbackParams.h
@@ -33,6 +33,17 @@ struct GattCharacteristicWriteCBParams {
     const uint8_t *data;   /**< Incoming data, variable length. */
 };
 
+struct GattCharacteristicReadCBParams {
+    GattAttribute::Handle_t charHandle;
+    enum Type {
+        GATTS_CHAR_OP_INVALID               = 0x00,  /**< Invalid Operation. */
+        GATTS_CHAR_OP_READ_REQ              = 0x0A,  /**< Read Request. */
+    } op;                  /**< Type of write operation, */
+    uint16_t       offset; /**< Offset for the read operation. */
+    uint16_t       *len;   /**< Length of the outgoing data. */
+    uint8_t        *data;  /**< Outgoing data, variable length. */
+};
+
 struct GattCharacteristicWriteAuthCBParams {
     GattAttribute::Handle_t  charHandle;
     uint16_t                 offset; /**< Offset for the write operation. */

--- a/public/GattServer.h
+++ b/public/GattServer.h
@@ -64,10 +64,14 @@ private:
     void setOnDataWritten(T *objPtr, void (T::*memberPtr)(const GattCharacteristicWriteCBParams *context)) {
         onDataWritten.add(objPtr, memberPtr);
     }
-    void setOnDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP)) {onDataRead.add(callback);}
+    ble_error_t setOnDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP)) {
+        onDataRead.add(callback);
+        return BLE_ERROR_NONE;
+    }
     template <typename T>
-    void setOnDataRead(T *objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context)) {
+    ble_error_t setOnDataRead(T *objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context)) {
         onDataRead.add(objPtr, memberPtr);
+        return BLE_ERROR_NONE;
     }
     void setOnUpdatesEnabled(EventCallback_t callback) {onUpdatesEnabled = callback;}
     void setOnUpdatesDisabled(EventCallback_t callback) {onUpdatesDisabled = callback;}

--- a/public/GattServer.h
+++ b/public/GattServer.h
@@ -34,6 +34,7 @@ protected:
         characteristicCount(0),
         onDataSent(),
         onDataWritten(),
+        onDataRead(),
         onUpdatesEnabled(NULL),
         onUpdatesDisabled(NULL),
         onConfirmationReceived(NULL) {
@@ -63,6 +64,11 @@ private:
     void setOnDataWritten(T *objPtr, void (T::*memberPtr)(const GattCharacteristicWriteCBParams *context)) {
         onDataWritten.add(objPtr, memberPtr);
     }
+    void setOnDataRead(void (*callback)(const GattCharacteristicReadCBParams *eventDataP)) {onDataRead.add(callback);}
+    template <typename T>
+    void setOnDataRead(T *objPtr, void (T::*memberPtr)(const GattCharacteristicReadCBParams *context)) {
+        onDataRead.add(objPtr, memberPtr);
+    }
     void setOnUpdatesEnabled(EventCallback_t callback) {onUpdatesEnabled = callback;}
     void setOnUpdatesDisabled(EventCallback_t callback) {onUpdatesDisabled = callback;}
     void setOnConfirmationReceived(EventCallback_t callback) {onConfirmationReceived = callback;}
@@ -71,6 +77,12 @@ protected:
     void handleDataWrittenEvent(const GattCharacteristicWriteCBParams *params) {
         if (onDataWritten.hasCallbacksAttached()) {
             onDataWritten.call(params);
+        }
+    }
+
+    void handleDataReadEvent(const GattCharacteristicReadCBParams *params) {
+        if (onDataRead.hasCallbacksAttached()) {
+            onDataRead.call(params);
         }
     }
 
@@ -109,6 +121,7 @@ protected:
 private:
     CallChainOfFunctionPointersWithContext<unsigned> onDataSent;
     CallChainOfFunctionPointersWithContext<const GattCharacteristicWriteCBParams *> onDataWritten;
+    CallChainOfFunctionPointersWithContext<const GattCharacteristicReadCBParams *> onDataRead;
     EventCallback_t onUpdatesEnabled;
     EventCallback_t onUpdatesDisabled;
     EventCallback_t onConfirmationReceived;


### PR DESCRIPTION
Added a callback for when a characteristic is being read. This is necessary for characteristics whose values are generated on demand.