### PR TITLE
Removed zeroing of UUID bytes 2 and 3. This is specific to the Nordic implementation.

### DIFF
--- a/common/UUID.cpp
+++ b/common/UUID.cpp
@@ -81,12 +81,6 @@ UUID::UUID(const LongUUIDBytes_t longUUID) : type(UUID_TYPE_SHORT), baseUUID(), 
 
         if (baseUUID[index] != 0) {
             type = UUID_TYPE_LONG;
-
-            /* zero out the 16-bit part in the base; this will help equate long
-             * UUIDs when they differ only in this 16-bit relative part.*/
-            baseUUID[2] = 0;
-            baseUUID[3] = 0;
-
             return;
         }
     }


### PR DESCRIPTION
This code should be moved to the Nordic BLE_API implementation. It interferes with implementations of the BLE_API on other stacks/radios.