### PR TITLE
Added methods to determine if updates are enabled for a given characteristic handle.

### DIFF
--- a/public/BLEDevice.h
+++ b/public/BLEDevice.h
@@ -450,13 +450,13 @@ public:
     /**
      * Return the updates enabled status for the current connection from the CCCD
      *
-     * @param  attributeHandle
-     *           The handle of the characteristic's value attribute 
+     * @param  characteristic
+     *           The characteristic
      *
      * @return true if the connection and handle are found and updates are
      *         enabled. false otherwise.
      */
-    bool updatesEnabled(GattAttribute::Handle_t attributeHandle);
+    bool updatesEnabled(const GattCharacteristic &characteristic);
 
     /**
      * Return the connection-specific updates enabled status from the CCCD
@@ -464,13 +464,13 @@ public:
      * @param  connectionHandle
      *           The connection handle
      *
-     * @param  attributeHandle
-     *           The handle of the characteristic's value attribute 
+     * @param  characteristic
+     *           The characteristic
      *
      * @return true if the connection and handle are found and updates are
      *         enabled. false otherwise.
      */
-    bool updatesEnabled(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle);
+    bool updatesEnabled(Gap::Handle_t connectionHandle, const GattCharacteristic &characteristic);
 
     /**
      * Yield control to the BLE stack or to other tasks waiting for events. This
@@ -997,15 +997,15 @@ BLEDevice::updateCharacteristicValue(Gap::Handle_t connectionHandle, GattAttribu
 }
 
 inline bool
-BLEDevice::updatesEnabled(GattAttribute::Handle_t attributeHandle)
+BLEDevice::updatesEnabled(const GattCharacteristic &characteristic)
 {
-    return transport->getGattServer().updatesEnabled(attributeHandle);
+    return transport->getGattServer().updatesEnabled(characteristic);
 }
 
 inline bool
-BLEDevice::updatesEnabled(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle)
+BLEDevice::updatesEnabled(Gap::Handle_t connectionHandle, const GattCharacteristic &characteristic)
 {
-    return transport->getGattServer().updatesEnabled(connectionHandle, attributeHandle);
+    return transport->getGattServer().updatesEnabled(connectionHandle, characteristic);
 }
 
 inline void

--- a/public/BLEDevice.h
+++ b/public/BLEDevice.h
@@ -433,7 +433,7 @@ public:
      */
     ble_error_t readCharacteristicValue(GattAttribute::Handle_t attributeHandle, uint8_t *buffer, uint16_t *lengthP);
     /**
-     * A version of the same as above with connection handle parameter to allow fetches for connection-specific multivalued attribtues (such as the CCCDs).
+     * A version of the same as above with connection handle parameter to allow fetches for connection-specific multivalued attributes (such as the CCCDs).
      */
     ble_error_t readCharacteristicValue(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, uint8_t *buffer, uint16_t *lengthP);
 
@@ -443,9 +443,34 @@ public:
      */
     ble_error_t updateCharacteristicValue(GattAttribute::Handle_t attributeHandle, const uint8_t *value, uint16_t size, bool localOnly = false);
     /**
-     * A version of the same as above with connection handle parameter to allow updates for connection-specific multivalued attribtues (such as the CCCDs).
+     * A version of the same as above with connection handle parameter to allow updates for connection-specific multivalued attributes (such as the CCCDs).
      */
     ble_error_t updateCharacteristicValue(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, const uint8_t *value, uint16_t size, bool localOnly = false);
+
+    /**
+     * Return the updates enabled status for the current connection from the CCCD
+     *
+     * @param  attributeHandle
+     *           The handle of the characteristic's value attribute 
+     *
+     * @return true if the connection and handle are found and updates are
+     *         enabled. false otherwise.
+     */
+    bool updatesEnabled(GattAttribute::Handle_t attributeHandle);
+
+    /**
+     * Return the connection-specific updates enabled status from the CCCD
+     *
+     * @param  connectionHandle
+     *           The connection handle
+     *
+     * @param  attributeHandle
+     *           The handle of the characteristic's value attribute 
+     *
+     * @return true if the connection and handle are found and updates are
+     *         enabled. false otherwise.
+     */
+    bool updatesEnabled(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle);
 
     /**
      * Yield control to the BLE stack or to other tasks waiting for events. This
@@ -969,6 +994,18 @@ inline ble_error_t
 BLEDevice::updateCharacteristicValue(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, const uint8_t *value, uint16_t size, bool localOnly)
 {
     return transport->getGattServer().updateValue(connectionHandle, attributeHandle, const_cast<uint8_t *>(value), size, localOnly);
+}
+
+inline bool
+BLEDevice::updatesEnabled(GattAttribute::Handle_t attributeHandle)
+{
+    return transport->getGattServer().updatesEnabled(attributeHandle);
+}
+
+inline bool
+BLEDevice::updatesEnabled(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle)
+{
+    return transport->getGattServer().updatesEnabled(connectionHandle, attributeHandle);
 }
 
 inline void

--- a/public/GattServer.h
+++ b/public/GattServer.h
@@ -51,8 +51,8 @@ private:
     virtual ble_error_t readValue(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP) = 0;
     virtual ble_error_t updateValue(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false) = 0;
     virtual ble_error_t updateValue(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false) = 0;
-    virtual bool updatesEnabled(GattAttribute::Handle_t attributeHandle)                                        = 0;
-    virtual bool updatesEnabled(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle)        = 0;
+    virtual bool updatesEnabled(const GattCharacteristic &characteristic)                                       = 0;
+    virtual bool updatesEnabled(Gap::Handle_t connectionHandle, const GattCharacteristic &characteristic)       = 0;
     virtual ble_error_t initializeGATTDatabase(void)                                                            = 0;
 
     // ToDo: For updateValue, check the CCCD to see if the value we are

--- a/public/GattServer.h
+++ b/public/GattServer.h
@@ -51,6 +51,8 @@ private:
     virtual ble_error_t readValue(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle, uint8_t buffer[], uint16_t *lengthP) = 0;
     virtual ble_error_t updateValue(GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false) = 0;
     virtual ble_error_t updateValue(Gap::Handle_t connectionHandle, GattAttribute::Handle_t, const uint8_t[], uint16_t, bool localOnly = false) = 0;
+    virtual bool updatesEnabled(GattAttribute::Handle_t attributeHandle)                                        = 0;
+    virtual bool updatesEnabled(Gap::Handle_t connectionHandle, GattAttribute::Handle_t attributeHandle)        = 0;
     virtual ble_error_t initializeGATTDatabase(void)                                                            = 0;
 
     // ToDo: For updateValue, check the CCCD to see if the value we are


### PR DESCRIPTION
In some cases, application behavior may be dependent upon whether updates (notifications/indications) are enabled for a characteristic. Since the CCCDs are being created within the adaptation layer, the application does not know the handle of the CCCD attribute for a given characteristic. This allows the application to determine the status from the characteristic's value handle.