### PR TITLE
use mbed-classic as mbed dependency

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,7 +19,7 @@
     }
   ],
   "dependencies": {
-    "mbed": "^3.0.2"
+    "mbed-classic":"~0.0.1"
   },
   "targetDependencies": {
     "nrf51822": {


### PR DESCRIPTION
We should probably pull in mbedOS / mbed-classic based on a target dependency, but using this gets things building on mbed-classic for now.