### PR TITLE
Revert "use mbed-classic as mbed dependency"

### DIFF
--- a/module.json
+++ b/module.json
@@ -19,7 +19,7 @@
     }
   ],
   "dependencies": {
-    "mbed-classic":"~0.0.1"
+    "mbed": "^3.0.2"
   },
   "targetDependencies": {
     "nrf51822": {


### PR DESCRIPTION
Reverts mbedmicro/BLE_API#45
wanted to merge to develop first.