### PR TITLE
Fix link to Advanced samples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Currently supported services include:
 * UriBeacon
 * iBeacon
 
-The [documentation](https://docs.mbed.com/docs/ble-intros/en/latest/AdvSamples/Overview/)
+The [documentation](https://docs.mbed.com/docs/ble-intros/en/master/Advanced/Overview/)
 contains an overview on how to create new, application-specific services.
 
 # Getting Started


### PR DESCRIPTION
Fix for #189, please check whether it's the right link.
